### PR TITLE
Separate `array_pop()` and `explode()`.

### DIFF
--- a/src/ThemeToolkit.php
+++ b/src/ThemeToolkit.php
@@ -59,7 +59,8 @@ class ThemeToolkit
     public static function applyBricks(ConfigInterface $config, string...$classes)
     {
         array_walk($classes, function ($brick) use ($config) {
-            $baseClassName = array_pop(explode('\\', $brick));
+            $splitClassName = explode('\\', $brick);
+            $baseClassName  = array_pop($splitClassName);
             if ($config->hasKey($baseClassName)) {
                 $brick_object = new $brick($config->getSubConfig($baseClassName));
                 $brick_object->apply();


### PR DESCRIPTION
As outlined in #11, using `array_pop( explode() )` results in a PHP error when `WP_DEBUG` is set true. Separating this line means we can pass the `$splitClassName` variable by reference, as `array_pop()` expects.

Fixes #11