### PR TITLE
Readme Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ use Gamajo\ThemeToolkit\Templates;
 use Gamajo\ThemeToolkit\ThemeSupport;
 use Gamajo\ThemeToolkit\Widgets;
 use Gamajo\ThemeToolkit\WidgetAreas;
+use Gamajo\ThemeToolkit\ThemeToolkit;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require __DIR__ . '/vendor/autoload.php';
+}
+
 
 add_action( 'after_setup_theme', __NAMESPACE__ . '\setup' );
 /**


### PR DESCRIPTION
Added a call to use the toolkit as it is used within the readme example and errors if not added.

Also added a couple lines to check and call composers autoload because unless called somewhere else when this is used in a theme it will error on the first use line for the config class.

