### PR TITLE
Menu Registration Brick

### DIFF
--- a/src/Menus.php
+++ b/src/Menus.php
@@ -8,7 +8,7 @@
  * @license   MIT
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace Gamajo\ThemeToolkit;
 
@@ -45,45 +45,49 @@ namespace Gamajo\ThemeToolkit;
  *
  * @package Gamajo\ThemeToolkit
  */
-class Menus extends Brick {
+class Menus extends Brick
+{
 
-	const REGISTER = 'register';
-	const UNREGISTER = 'unregister';
+    const REGISTER = 'register';
+    const UNREGISTER = 'unregister';
 
-	/**
-	 * Apply nav menu registrations and unregistrations.
-	 */
-	public function apply() {
-		if ( $this->config->hasKey( self::REGISTER ) ) {
-			$registerConfig = $this->config->getSubConfig( self::REGISTER );
-			$this->register( $registerConfig->getArrayCopy() );
-		}
+    /**
+     * Apply nav menu registrations and unregistrations.
+     */
+    public function apply()
+    {
+        if ($this->config->hasKey(self::REGISTER)) {
+            $registerConfig = $this->config->getSubConfig(self::REGISTER);
+            $this->register($registerConfig->getArrayCopy());
+        }
 
-		if ( $this->config->hasKey( self::UNREGISTER ) ) {
-			$unregisterConfig = $this->config->getSubConfig( self::UNREGISTER );
-			$this->unregister( $unregisterConfig->getArrayCopy() );
-		}
-	}
+        if ($this->config->hasKey(self::UNREGISTER)) {
+            $unregisterConfig = $this->config->getSubConfig(self::UNREGISTER);
+            $this->unregister($unregisterConfig->getArrayCopy());
+        }
+    }
 
-	/**
-	 * Register nav menus.
-	 *
-	 * @param array $menus Arguments for nav menus to be registered.
-	 */
-	public function register( array $menus ) {
-		array_walk( $menus, function ( array $menu ) {
-			\register_nav_menus( $menu );
-		} );
-	}
+    /**
+     * Register nav menus.
+     *
+     * @param array $menus Arguments for nav menus to be registered.
+     */
+    public function register(array $menus)
+    {
+        array_walk($menus, function (array $menu) {
+            \register_nav_menus($menu);
+        });
+    }
 
-	/**
-	 * Unregister nav menus.
-	 *
-	 * @param array $menus Array of nav menu names to unregister.
-	 */
-	public function unregister( array $menus ) {
-		array_walk( $menus, function ( string $menu ) {
-			\unregister_nav_menu( $menu );
-		} );
-	}
+    /**
+     * Unregister nav menus.
+     *
+     * @param array $menus Array of nav menu names to unregister.
+     */
+    public function unregister(array $menus)
+    {
+        array_walk($menus, function (string $menu) {
+            \unregister_nav_menu($menu);
+        });
+    }
 }

--- a/src/Menus.php
+++ b/src/Menus.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file contains elements for nav menus in WordPress
+ *
+ * @package   Gamajo\ThemeToolkit
+ * @author    Gary Jones
+ * @copyright Gamajo
+ * @license   MIT
+ */
+
+declare( strict_types=1 );
+
+namespace Gamajo\ThemeToolkit;
+
+/**
+ * Register or unregister nav menus for a WordPress theme.
+ * *
+ * Example config:
+ *
+ * ```
+ * $gamajo_menus = [
+ *     Menus::UNREGISTER => [
+ *         'main-nav',
+ *     ],
+ *     Menus::REGISTER => [
+ *         [
+ *             'location'    => 'new-main-nav',
+ *             'description' => __( 'Primary navigation menu', 'your-text-domain' ),
+ *         ],
+ *     ],
+ * ];
+ * ```
+ *
+ * And then:
+ *
+ * ```
+ * return [
+ *     'Gamajo' => [
+ *         'Theme' => [
+ *             ThemeToolkit::MENUS => $gamajo_menus,
+ *         ],
+ *     ],
+ * ];
+ * ```
+ *
+ * @package Gamajo\ThemeToolkit
+ */
+class Menus extends Brick {
+
+	const REGISTER = 'register';
+	const UNREGISTER = 'unregister';
+
+	/**
+	 * Apply nav menu registrations and unregistrations.
+	 */
+	public function apply() {
+		if ( $this->config->hasKey( self::REGISTER ) ) {
+			$registerConfig = $this->config->getSubConfig( self::REGISTER );
+			$this->register( $registerConfig->getArrayCopy() );
+		}
+
+		if ( $this->config->hasKey( self::UNREGISTER ) ) {
+			$unregisterConfig = $this->config->getSubConfig( self::UNREGISTER );
+			$this->unregister( $unregisterConfig->getArrayCopy() );
+		}
+	}
+
+	/**
+	 * Register nav menus.
+	 *
+	 * @param array $menus Arguments for nav menus to be registered.
+	 */
+	public function register( array $menus ) {
+		array_walk( $menus, function ( array $menu ) {
+			\register_nav_menus( $menu );
+		} );
+	}
+
+	/**
+	 * Unregister nav menus.
+	 *
+	 * @param array $menus Array of nav menu names to unregister.
+	 */
+	public function unregister( array $menus ) {
+		array_walk( $menus, function ( string $menu ) {
+			\unregister_nav_menu( $menu );
+		} );
+	}
+}

--- a/src/Menus.php
+++ b/src/Menus.php
@@ -24,8 +24,7 @@ namespace Gamajo\ThemeToolkit;
  *     ],
  *     Menus::REGISTER => [
  *         [
- *             'location'    => 'new-main-nav',
- *             'description' => __( 'Primary navigation menu', 'your-text-domain' ),
+ *             'new-main-nav' => __( 'Primary navigation menu', 'your-text-domain' ),
  *         ],
  *     ],
  * ];
@@ -74,7 +73,7 @@ class Menus extends Brick
      */
     public function register(array $menus)
     {
-        array_walk($menus, function (array $menu) {
+        array_walk($menus, function ($menu) {
             \register_nav_menus($menu);
         });
     }

--- a/src/ThemeToolkit.php
+++ b/src/ThemeToolkit.php
@@ -42,6 +42,7 @@ class ThemeToolkit
     const THEMESUPPORT = 'ThemeSupport';
     const WIDGETAREAS = 'WidgetAreas';
     const WIDGETS = 'Widgets';
+    const MENUS = 'Menus';
 
     /**
      * For a given list of bricks, instantiate each brick, pass in the right part of the


### PR DESCRIPTION
I added a brick to deal with me normal theme nav menu registration and unregistering. 

I noticed you can do this in the config of the theme supports for the genesis toolkit but this is not an option I am aware of for the non-genesis toolkit.

